### PR TITLE
Move API keys to Cloudflare Pages Functions proxies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ dist/
 .env
 .env.local
 .env.*.local
+.dev.vars
 
 # IDE
 .idea/

--- a/functions/api/rawg.js
+++ b/functions/api/rawg.js
@@ -1,0 +1,55 @@
+// Cloudflare Pages Function - RAWG Game Search Proxy
+// Keeps RAWG API key server-side, away from client code
+//
+// Route: GET /api/rawg?query=<search>
+// Env: RAWG_API_KEY
+
+export async function onRequestGet(context) {
+  const { request, env } = context;
+
+  const corsHeaders = {
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Methods': 'GET, OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type',
+  };
+
+  if (request.method === 'OPTIONS') {
+    return new Response(null, { headers: corsHeaders });
+  }
+
+  try {
+    const url = new URL(request.url);
+    const query = url.searchParams.get('query');
+
+    if (!query) {
+      return new Response(
+        JSON.stringify({ error: 'Missing query parameter' }),
+        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    const rawgUrl = `https://api.rawg.io/api/games?search=${encodeURIComponent(query)}&page_size=6&key=${env.RAWG_API_KEY}`;
+    const response = await fetch(rawgUrl);
+
+    if (!response.ok) {
+      console.error('RAWG API error:', response.status);
+      return new Response(
+        JSON.stringify({ error: 'RAWG API error' }),
+        { status: response.status, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    const data = await response.json();
+    return new Response(
+      JSON.stringify(data),
+      { headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    );
+
+  } catch (error) {
+    console.error('RAWG proxy error:', error);
+    return new Response(
+      JSON.stringify({ error: 'Failed to search games' }),
+      { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    );
+  }
+}

--- a/functions/api/tmdb.js
+++ b/functions/api/tmdb.js
@@ -1,0 +1,58 @@
+// Cloudflare Pages Function - TMDB Search Proxy
+// Keeps TMDB API key server-side, away from client code
+//
+// Route: GET /api/tmdb?query=<search>&type=<tv|movie>
+// Env: TMDB_API_KEY (JWT Bearer token)
+
+export async function onRequestGet(context) {
+  const { request, env } = context;
+
+  const corsHeaders = {
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Methods': 'GET, OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type',
+  };
+
+  if (request.method === 'OPTIONS') {
+    return new Response(null, { headers: corsHeaders });
+  }
+
+  try {
+    const url = new URL(request.url);
+    const query = url.searchParams.get('query');
+    const type = url.searchParams.get('type');
+
+    if (!query || !type || !['tv', 'movie'].includes(type)) {
+      return new Response(
+        JSON.stringify({ error: 'Missing or invalid query/type parameter' }),
+        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    const tmdbUrl = `https://api.themoviedb.org/3/search/${type}?query=${encodeURIComponent(query)}`;
+    const response = await fetch(tmdbUrl, {
+      headers: { Authorization: 'Bearer ' + env.TMDB_API_KEY }
+    });
+
+    if (!response.ok) {
+      console.error('TMDB API error:', response.status);
+      return new Response(
+        JSON.stringify({ error: 'TMDB API error' }),
+        { status: response.status, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    const data = await response.json();
+    return new Response(
+      JSON.stringify(data),
+      { headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    );
+
+  } catch (error) {
+    console.error('TMDB proxy error:', error);
+    return new Response(
+      JSON.stringify({ error: 'Failed to search TMDB' }),
+      { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    );
+  }
+}

--- a/public/index.html
+++ b/public/index.html
@@ -450,9 +450,6 @@ var selectedMedia = null;
 var searchTimeout = null;
 var isDemo = false;
 
-// API keys for media search
-var TMDB_KEY = 'eyJhbGciOiJIUzI1NiJ9.eyJhdWQiOiI2OGRkOTMwYWI2MzdhYmYyNzk4MTdkMzNhZDg2OWQ2ZSIsIm5iZiI6MTc0NzI3MjMxNi4xNzksInN1YiI6IjY4MjVlMjdjOGU5ZTI4YjcyYmMwNDY5OCIsInNjb3BlcyI6WyJhcGlfcmVhZCJdLCJ2ZXJzaW9uIjoxfQ.v1tacryptkmjKLhUcLzNqy1EFrpqwJY_JpXSMWsqRqY';
-
 var icons = {book:'📚',tv:'📺',movie:'🎬',game:'🎮',other:'📦'};
 var labels = {book:'Book',tv:'TV',movie:'Movie',game:'Game',other:'Other'};
 var progLabels = {book:'Page Number',tv:'Episode & Timecode',movie:'Timecode',game:'Quest/Chapter',other:'Progress'};
@@ -1049,9 +1046,7 @@ function searchMedia(query) {
 
 function searchTMDB(query, type) {
   console.log('Searching TMDB for:', query, type);
-  fetch('https://api.themoviedb.org/3/search/'+type+'?query='+encodeURIComponent(query), {
-    headers: {Authorization: 'Bearer ' + TMDB_KEY}
-  })
+  fetch('/api/tmdb?query='+encodeURIComponent(query)+'&type='+type)
   .then(function(r){
     console.log('TMDB response status:', r.status);
     if (!r.ok) throw new Error('TMDB API error: ' + r.status);
@@ -1110,7 +1105,7 @@ function searchBooks(query) {
 
 function searchGames(query) {
   console.log('Searching Games for:', query);
-  fetch('https://api.rawg.io/api/games?search='+encodeURIComponent(query)+'&page_size=6&key=c542e67aec3a4340908f9de9e86038af')
+  fetch('/api/rawg?query='+encodeURIComponent(query))
   .then(function(r){
     console.log('Games response status:', r.status);
     if (!r.ok) throw new Error('Games API error: ' + r.status);


### PR DESCRIPTION
Add server-side proxy functions for TMDB and RAWG APIs so keys are stored as encrypted environment variables instead of exposed in client-side JavaScript. Google Books search remains direct (no key).

- Create functions/api/tmdb.js for TMDB movie/TV search proxy
- Create functions/api/rawg.js for RAWG game search proxy
- Remove TMDB_KEY from client code, update fetch URLs to /api/ routes
- Add .dev.vars to .gitignore for local development secrets