### PR TITLE
Add entry detail panel, log progress, and fix three bugs

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -253,7 +253,7 @@ function normalizeRecord(rec, collection) {
   var status  = val.status  || (val.progress ? STATUS.inProgress : STATUS.wantTo);
   return Object.assign({}, val, {
     type:type, authors:authors, genres:genres, status:status,
-    progress:val.progress||null, rkey:rkey, uri:rec.uri, collection:collection
+    progress:val.progress||null, history:val.history||[], rkey:rkey, uri:rec.uri, collection:collection
   });
 }
 
@@ -273,6 +273,7 @@ function buildRecord(entry, collection) {
   if (entry.type === 'book'    && entry.authors?.length) rec.authors   = entry.authors;
   if (entry.type === 'game'    && entry.developer)       rec.developer = entry.developer;
   if (entry.type === 'podcast' && entry.creator)         rec.creator   = entry.creator;
+  if (entry.history?.length) rec.history = entry.history;
   return rec;
 }
 
@@ -385,6 +386,15 @@ function init() {
   $('entry-modal').onclick = function(e) { if (e.target === this) closeModal(); };
   $('save-btn').onclick    = saveEntry;
   $('delete-btn').onclick  = deleteEntry;
+
+  // Detail panel
+  $('detail-back').onclick = closeDetail;
+
+  // Log modal
+  $('log-modal-close').onclick  = closeLogModal;
+  $('log-modal-cancel').onclick = closeLogModal;
+  $('log-modal').onclick = function(e) { if (e.target === this) closeLogModal(); };
+  $('log-modal-save').onclick   = submitLog;
 
 
   // Search
@@ -538,8 +548,8 @@ async function loadEntries() {
   $('entries').innerHTML = '';
   $('empty').classList.add('hidden');
   try {
-    await atpGetEntries();
-    render(); updateStats();
+    await Promise.all([atpGetEntries(), atpGetLists()]);
+    render(); updateStats(); renderLists();
   } catch(e) {
     toast('Failed to load: ' + e.message, 'error');
     render();
@@ -931,7 +941,7 @@ function render() {
     var typeLabel = LABELS[e.type] || e.type;
 
     return '<button class="bc-card bc-card--' + e.type + '"'
-      + ' onclick="openEdit(\'' + esc(e.rkey) + '\',\'' + esc(e.collection) + '\')"'
+      + ' onclick="openDetail(\'' + esc(e.rkey) + '\',\'' + esc(e.collection) + '\')"'
       + ' aria-label="' + esc(e.title) + '">'
 
       + '<div class="bc-card__spine" aria-hidden="true"></div>'
@@ -1309,17 +1319,38 @@ function searchBooks(query) {
   fetch('https://www.googleapis.com/books/v1/volumes?q=' + encodeURIComponent(query) + '&maxResults=6')
     .then(function(r) { if (!r.ok) throw new Error(r.status); return r.json(); })
     .then(function(data) {
-      if (!data.items?.length) { renderSearchResults([]); return; }
-      renderSearchResults(data.items.map(function(item) {
-        var v = item.volumeInfo;
-        var isbn = (v.industryIdentifiers||[]).find(function(x) { return x.type==='ISBN_13'; });
+      if (data.items?.length) {
+        renderSearchResults(data.items.map(function(item) {
+          var v = item.volumeInfo;
+          var isbn = (v.industryIdentifiers||[]).find(function(x) { return x.type==='ISBN_13'; });
+          return {
+            title:  v.title || 'Unknown',
+            author: (v.authors||[]).join(', '),
+            year:   (v.publishedDate||'').slice(0,4),
+            cover:  v.imageLinks?.thumbnail || v.imageLinks?.smallThumbnail || '',
+            isbn13: isbn ? isbn.identifier : '',
+            pages:  v.pageCount || ''
+          };
+        }));
+      } else {
+        searchOpenLibrary(query);
+      }
+    })
+    .catch(function() { searchOpenLibrary(query); });
+}
+
+function searchOpenLibrary(query) {
+  fetch('https://openlibrary.org/search.json?q=' + encodeURIComponent(query) + '&limit=8&fields=title,author_name,cover_i,number_of_pages_median,first_publish_year')
+    .then(function(r) { if (!r.ok) throw new Error(r.status); return r.json(); })
+    .then(function(data) {
+      if (!data.docs?.length) { renderSearchResults([]); return; }
+      renderSearchResults(data.docs.slice(0, 6).map(function(doc) {
         return {
-          title:  v.title || 'Unknown',
-          author: (v.authors||[]).join(', '),
-          year:   (v.publishedDate||'').slice(0,4),
-          cover:  v.imageLinks?.thumbnail || v.imageLinks?.smallThumbnail || '',
-          isbn13: isbn ? isbn.identifier : '',
-          pages:  v.pageCount || ''
+          title:  doc.title || 'Unknown',
+          author: (doc.author_name||[]).join(', '),
+          year:   doc.first_publish_year ? String(doc.first_publish_year) : '',
+          cover:  doc.cover_i ? 'https://covers.openlibrary.org/b/id/' + doc.cover_i + '-M.jpg' : '',
+          pages:  doc.number_of_pages_median || ''
         };
       }));
     })
@@ -1631,6 +1662,330 @@ function toggleHideCovers() {
   var on = app.classList.contains('is-hide-covers');
   localStorage.setItem('bc_hide_covers', on);
   renderSettings();
+}
+
+// ── Detail panel ─────────────────────────────────────────────
+var detailRkey       = null;
+var detailCollection = null;
+
+function openDetail(rkey, collection) {
+  var e = entries.find(function(x) { return x.rkey === rkey && x.collection === collection; });
+  if (!e) return;
+  detailRkey       = rkey;
+  detailCollection = collection;
+  renderDetail(e);
+  var panel = $('detail-panel');
+  panel.classList.add('is-open');
+  panel.setAttribute('aria-hidden', 'false');
+  document.body.style.overflow = 'hidden';
+}
+
+function closeDetail() {
+  $('detail-panel').classList.remove('is-open');
+  $('detail-panel').setAttribute('aria-hidden', 'true');
+  document.body.style.overflow = '';
+  detailRkey = null;
+  detailCollection = null;
+}
+
+function _detailProgPct(entry) {
+  var p = entry.progress;
+  if (!p || typeof p === 'string') return null;
+  if (entry.type === 'book'  && p.currentPage && p.totalPages) return Math.min(100, Math.round(p.currentPage / p.totalPages * 100));
+  if (entry.type === 'game'  && p.completionPercent)            return Math.min(100, p.completionPercent);
+  if (entry.status === STATUS.completed)                         return 100;
+  return null;
+}
+
+function _detailProgLabel(entry) {
+  var p = entry.progress;
+  if (!p) return null;
+  if (typeof p === 'string') return p;
+  var t = entry.type;
+  if (t === 'book') {
+    if (p.currentPage && p.totalPages) return 'Page\u202f' + p.currentPage + '\u202f/\u202f' + p.totalPages;
+    if (p.currentPage) return 'Page\u202f' + p.currentPage;
+  }
+  if (t === 'show') {
+    var parts = [];
+    if (p.season)  parts.push('Season\u202f' + p.season);
+    if (p.episode) parts.push('Episode\u202f' + p.episode);
+    return parts.join(', ') || null;
+  }
+  if (t === 'game') {
+    var gp = [];
+    if (p.playtimeMinutes)   gp.push(Math.round(p.playtimeMinutes / 60) + '\u202fh played');
+    if (p.completionPercent) gp.push(p.completionPercent + '%\u202fdone');
+    if (p.narrativePosition) gp.push(p.narrativePosition);
+    return gp.join(' · ') || null;
+  }
+  if (t === 'podcast') {
+    var pp = [];
+    if (p.episodeNumber)   pp.push('Episode\u202f' + p.episodeNumber);
+    if (p.positionSeconds) pp.push(fmtSecs(p.positionSeconds));
+    return pp.join(' · ') || null;
+  }
+  return null;
+}
+
+function _historyItemDesc(item, type) {
+  if (item.action === 'completed') return 'Marked complete';
+  var p = item.progress;
+  if (!p) return 'Progress logged';
+  if (typeof p === 'string') return p;
+  if (type === 'book') {
+    if (p.currentPage && p.totalPages) return 'p.\u202f' + p.currentPage + ' / ' + p.totalPages;
+    if (p.currentPage) return 'p.\u202f' + p.currentPage;
+  }
+  if (type === 'show') {
+    var parts = [];
+    if (p.season)  parts.push('S' + p.season);
+    if (p.episode) parts.push('E' + p.episode);
+    return parts.join('\u202f') || 'Progress logged';
+  }
+  if (type === 'game') {
+    var gp = [];
+    if (p.completionPercent) gp.push(p.completionPercent + '%');
+    if (p.playtimeMinutes)   gp.push(Math.round(p.playtimeMinutes / 60) + 'h');
+    return gp.join(' · ') || 'Progress logged';
+  }
+  if (type === 'podcast') {
+    if (p.episodeNumber) return 'Ep\u202f' + p.episodeNumber;
+  }
+  return 'Progress logged';
+}
+
+function renderDetail(e) {
+  var scroll = $('detail-scroll');
+  var color  = DOT_COLORS[e.type] || '#888';
+  var subtitle = (e.authors||[]).join(', ') || e.creator || e.developer || '';
+
+  var heroStyle = e.coverUrl
+    ? 'background-image:url(' + esc(e.coverUrl) + ');background-size:cover;background-position:center'
+    : 'background:' + (COVER_BG[e.type] || COVER_BG.book);
+
+  var pct   = _detailProgPct(e);
+  var pLbl  = _detailProgLabel(e);
+  var inProg = e.status === STATUS.inProgress;
+  var isComplete = e.status === STATUS.completed;
+
+  var heroHtml = '<div class="bc-detail__hero" style="' + heroStyle + '">'
+    + '<div class="bc-detail__hero-scrim"></div>'
+    + '<div class="bc-detail__hero-body">'
+    + '<span class="bc-detail__stamp">' + esc(LABELS[e.type] || e.type) + '</span>'
+    + '<h2 class="bc-detail__title">' + esc(e.title) + '</h2>'
+    + (subtitle ? '<p class="bc-detail__sub">' + esc(subtitle) + '</p>' : '')
+    + '</div>'
+    + '</div>';
+
+  var progCard = '';
+  if (e.status !== STATUS.wantTo) {
+    var trackHtml = '';
+    if (pct !== null) {
+      trackHtml = '<div class="bc-detail__track">'
+        + '<div class="bc-detail__fill" style="width:' + pct + '%;background:' + color + '"></div>'
+        + '</div>'
+        + '<div class="bc-detail__track-row"><span>' + pct + '%</span><span>' + esc(STATUS_LABELS[e.status] || '') + '</span></div>';
+    }
+
+    var btns = '';
+    if (!isComplete) {
+      btns = '<div class="bc-detail__btns">'
+        + '<button class="bc-btn bc-btn--secondary bc-detail__log-btn" onclick="openLogModal(\'' + esc(e.rkey) + '\',\'' + esc(e.collection) + '\')">'
+        + '<svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true"><circle cx="8" cy="8" r="6.5" stroke="currentColor" stroke-width="1.3"/><line x1="8" y1="5" x2="8" y2="8" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/><line x1="8" y1="8" x2="10" y2="10" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/></svg>'
+        + 'Log progress</button>'
+        + '<button class="bc-btn bc-btn--secondary bc-detail__fin-btn" onclick="markDetailComplete()">'
+        + 'Mark complete</button>'
+        + '</div>';
+    }
+
+    progCard = '<div class="bc-detail__card">'
+      + '<div class="bc-detail__card-head">Progress</div>'
+      + (pLbl ? '<div class="bc-detail__prog-lbl">' + esc(pLbl) + '</div>' : '<p class="bc-detail__no-prog">No progress logged yet.</p>')
+      + trackHtml
+      + btns
+      + '</div>';
+  }
+
+  var notesCard = '';
+  if (e.notes) {
+    notesCard = '<div class="bc-detail__card">'
+      + '<div class="bc-detail__card-head">Notes</div>'
+      + '<blockquote class="bc-margin-note">'
+      + '<span class="bc-margin-note__mark" aria-hidden="true">\u201c</span>'
+      + '<p class="bc-margin-note__text">' + esc(e.notes) + '</p>'
+      + '</blockquote>'
+      + '</div>';
+  }
+
+  var historyCard = '';
+  var hist = (e.history || []).slice().reverse();
+  if (hist.length) {
+    historyCard = '<div class="bc-detail__card">'
+      + '<div class="bc-detail__card-head">History <span class="bc-detail__count">' + hist.length + '</span></div>'
+      + '<div class="bc-history">'
+      + hist.map(function(item) {
+          return '<div class="bc-history__item">'
+            + '<div class="bc-history__dot" style="background:' + color + ';opacity:0.7"></div>'
+            + '<div class="bc-history__body">'
+            + '<div class="bc-history__when">' + esc(fmtDate(item.ts)) + '</div>'
+            + '<div class="bc-history__what">' + esc(_historyItemDesc(item, e.type)) + '</div>'
+            + (item.note ? '<div class="bc-history__note">' + esc(item.note) + '</div>' : '')
+            + '</div>'
+            + '</div>';
+        }).join('')
+      + '</div>'
+      + '</div>';
+  }
+
+  var ratingHtml = '';
+  if (e.rating) {
+    var stars = '';
+    for (var i = 1; i <= 5; i++) stars += (i <= e.rating ? '★' : '☆');
+    ratingHtml = '<div class="bc-detail__card">'
+      + '<div class="bc-detail__card-head">Rating</div>'
+      + '<div style="font-size:22px;color:var(--accent);letter-spacing:2px">' + stars + '</div>'
+      + '</div>';
+  }
+
+  scroll.innerHTML = heroHtml
+    + '<div class="bc-detail__body">'
+    + progCard
+    + notesCard
+    + ratingHtml
+    + historyCard
+    + '</div>';
+
+  $('detail-edit').onclick = function() {
+    closeDetail();
+    openEdit(e.rkey, e.collection);
+  };
+}
+
+async function markDetailComplete() {
+  var e = entries.find(function(x) { return x.rkey === detailRkey && x.collection === detailCollection; });
+  if (!e) return;
+  var updated = Object.assign({}, e, {
+    status: STATUS.completed,
+    history: (e.history || []).concat([{ ts: new Date().toISOString(), action: 'completed' }])
+  });
+  await _saveEntryUpdate(updated);
+}
+
+// ── Log modal ─────────────────────────────────────────────────
+var logRkey       = null;
+var logCollection = null;
+
+function openLogModal(rkey, collection) {
+  var e = entries.find(function(x) { return x.rkey === rkey && x.collection === collection; });
+  if (!e) return;
+  logRkey       = rkey;
+  logCollection = collection;
+
+  var p = (e.progress && typeof e.progress !== 'string') ? e.progress : {};
+  var progFields = '';
+  if (e.type === 'book') {
+    progFields = '<div class="bc-progrow">'
+      + '<input class="bc-input" id="lf-page" type="number" min="0" placeholder="Page" value="' + (p.currentPage || '') + '">'
+      + '<span class="bc-progrow__of">of</span>'
+      + '<input class="bc-input" id="lf-total" type="number" min="1" placeholder="Total" value="' + (p.totalPages || '') + '">'
+      + '</div>';
+  } else if (e.type === 'show') {
+    progFields = '<div class="bc-progrow">'
+      + '<input class="bc-input" id="lf-season" type="number" min="1" placeholder="Season" value="' + (p.season || '') + '">'
+      + '<input class="bc-input" id="lf-episode" type="number" min="1" placeholder="Episode" value="' + (p.episode || '') + '">'
+      + '</div>';
+  } else if (e.type === 'game') {
+    progFields = '<div class="bc-progrow" style="margin-bottom:8px">'
+      + '<input class="bc-input" id="lf-hours" type="number" min="0" placeholder="Hours played" value="' + (p.playtimeMinutes ? Math.round(p.playtimeMinutes / 60) : '') + '">'
+      + '<input class="bc-input" id="lf-pct" type="number" min="0" max="100" placeholder="% done" value="' + (p.completionPercent || '') + '">'
+      + '</div>'
+      + '<input class="bc-input" id="lf-narrative" placeholder="Where are you in the story? (optional)" maxlength="128" value="' + esc(p.narrativePosition || '') + '">';
+  } else if (e.type === 'podcast') {
+    progFields = '<div class="bc-progrow">'
+      + '<input class="bc-input" id="lf-epnum" type="number" min="1" placeholder="Episode" value="' + (p.episodeNumber || '') + '">'
+      + '<input class="bc-input" id="lf-pos" placeholder="Position (1:23:45)" value="' + (p.positionSeconds ? fmtSecs(p.positionSeconds) : '') + '">'
+      + '</div>';
+  } else if (e.type === 'movie') {
+    progFields = '<p style="font-size:13px;color:var(--fg-3);font-style:italic;padding:4px 0">Status carries progress for films.</p>';
+  }
+
+  $('log-modal-body').innerHTML = '<div class="bc-log__entry-name">' + esc(e.title) + '</div>'
+    + (progFields ? '<div class="bc-field"><div class="bc-label">Progress</div>' + progFields + '</div>' : '')
+    + '<div class="bc-field">'
+    + '<div class="bc-label">Note <span class="bc-label__hint">optional</span></div>'
+    + '<textarea class="bc-textarea" id="lf-note" placeholder="Quick thought\u2026" rows="2"></textarea>'
+    + '</div>';
+
+  $('log-modal').style.display = 'flex';
+}
+
+function closeLogModal() {
+  $('log-modal').style.display = 'none';
+  logRkey = null; logCollection = null;
+}
+
+async function submitLog() {
+  var e = entries.find(function(x) { return x.rkey === logRkey && x.collection === logCollection; });
+  if (!e) return;
+  var now = new Date().toISOString();
+  var note = ($('lf-note') && $('lf-note').value.trim()) || null;
+
+  var newProgress = null;
+  if (e.type === 'book') {
+    var cp = parseInt($('lf-page') && $('lf-page').value) || null;
+    var tp = parseInt($('lf-total') && $('lf-total').value) || null;
+    if (cp || tp) newProgress = Object.assign({}, e.progress && typeof e.progress !== 'string' ? e.progress : {}, { currentPage:cp, totalPages:tp, updatedAt:now });
+  } else if (e.type === 'show') {
+    var se = parseInt($('lf-season') && $('lf-season').value) || null;
+    var ep = parseInt($('lf-episode') && $('lf-episode').value) || null;
+    if (se || ep) newProgress = { season:se, episode:ep, updatedAt:now };
+  } else if (e.type === 'game') {
+    var hr = parseFloat($('lf-hours') && $('lf-hours').value);
+    var pm = (!isNaN(hr) && hr > 0) ? Math.round(hr * 60) : null;
+    var pc = parseInt($('lf-pct') && $('lf-pct').value) || null;
+    var np = ($('lf-narrative') && $('lf-narrative').value.trim()) || null;
+    if (pm || pc || np) newProgress = { playtimeMinutes:pm, completionPercent:pc, narrativePosition:np, updatedAt:now };
+  } else if (e.type === 'podcast') {
+    var en = parseInt($('lf-epnum') && $('lf-epnum').value) || null;
+    var ps = parseSecs(($('lf-pos') && $('lf-pos').value.trim()) || '');
+    if (en || ps) newProgress = { episodeNumber:en, positionSeconds:ps, updatedAt:now };
+  }
+
+  var histItem = { ts: now, progress: newProgress || e.progress, note: note };
+  var updated = Object.assign({}, e, {
+    progress: newProgress || e.progress,
+    history:  (e.history || []).concat([histItem])
+  });
+
+  $('log-modal-save').textContent = 'Saving\u2026';
+  $('log-modal-save').disabled = true;
+  try {
+    await _saveEntryUpdate(updated);
+    closeLogModal();
+    toast('Progress logged!');
+  } catch(err) {
+    toast('Save failed: ' + err.message, 'error');
+  } finally {
+    $('log-modal-save').textContent = 'Save';
+    $('log-modal-save').disabled = false;
+  }
+}
+
+async function _saveEntryUpdate(updated) {
+  var idx = entries.findIndex(function(x) { return x.rkey === updated.rkey && x.collection === updated.collection; });
+  if (isDemo) {
+    if (idx >= 0) entries[idx] = updated;
+    saveDemoEntries();
+  } else {
+    await atpUpdateEntry(updated.rkey, updated.collection, updated);
+    await atpGetEntries();
+  }
+  render(); updateStats();
+  if (detailRkey === updated.rkey) {
+    var fresh = entries.find(function(x) { return x.rkey === updated.rkey && x.collection === updated.collection; });
+    if (fresh) renderDetail(fresh);
+  }
 }
 
 // ── Export ────────────────────────────────────────────────────

--- a/public/breadcrumbs.css
+++ b/public/breadcrumbs.css
@@ -93,6 +93,11 @@
   --ink: #F1E8D5; --ink-soft: #D5CAB3; --ink-muted: #A89E87; --ink-faint: #7C7360; --ink-whisper: rgba(241,232,213,0.18);
   --burgundy-wash:#3C2A2A; --moss-wash:#2A2F1E; --plum-wash:#2F2432;
   --ochre-wash:#332A1A; --rust-wash:#33231A; --teal-wash:#1F2B2A; --lavender-wash:#2A2438;
+  --moss:  #8FAF70; --moss-soft:  #6A9048; --moss-wash:  #2A3C20;
+  --plum:  #A87AB0; --plum-soft:  #7A5888; --plum-wash:  #2E2038;
+  --ochre: #D4A840; --ochre-soft: #A87C28; --ochre-wash: #382A10;
+  --rust:  #C8784A; --rust-soft:  #A05530; --rust-wash:  #382010;
+  --teal:  #70A09C; --teal-soft:  #487870; --teal-wash:  #183028;
   --shadow-xs: 0 1px 2px rgba(0,0,0,0.30);
   --shadow-sm: 0 2px 6px rgba(0,0,0,0.30), 0 1px 2px rgba(0,0,0,0.20);
   --shadow-book: 2px 2px 0 rgba(0,0,0,0.35);
@@ -426,11 +431,11 @@ input, textarea { font-family: inherit; }
 .bc-pill--movie   { background:var(--ochre-wash);  color:#7A5A26; border-color:rgba(176,136,72,0.3); }
 .bc-pill--game    { background:var(--rust-wash);   color:#72381F; border-color:rgba(164,90,60,0.3); }
 .bc-pill--podcast { background:var(--teal-wash);   color:#30504D; border-color:rgba(79,112,109,0.3); }
-[data-mode="dark"] .bc-pill--book    { background:rgba(95,107,67,0.22);   color:#c9d1a8; border-color:rgba(95,107,67,0.4); }
-[data-mode="dark"] .bc-pill--show    { background:rgba(107,78,113,0.25);  color:#d5b9d9; border-color:rgba(107,78,113,0.45); }
-[data-mode="dark"] .bc-pill--movie   { background:rgba(176,136,72,0.22);  color:#e6c896; border-color:rgba(176,136,72,0.4); }
-[data-mode="dark"] .bc-pill--game    { background:rgba(164,90,60,0.22);   color:#dca590; border-color:rgba(164,90,60,0.4); }
-[data-mode="dark"] .bc-pill--podcast { background:rgba(79,112,109,0.25);  color:#a9c4c1; border-color:rgba(79,112,109,0.4); }
+[data-mode="dark"] .bc-pill--book    { background:rgba(143,175,112,0.18); color:#8FAF70; border-color:rgba(143,175,112,0.35); }
+[data-mode="dark"] .bc-pill--show    { background:rgba(168,122,176,0.18); color:#A87AB0; border-color:rgba(168,122,176,0.35); }
+[data-mode="dark"] .bc-pill--movie   { background:rgba(212,168,64,0.18);  color:#D4A840; border-color:rgba(212,168,64,0.35); }
+[data-mode="dark"] .bc-pill--game    { background:rgba(200,120,74,0.18);  color:#C8784A; border-color:rgba(200,120,74,0.35); }
+[data-mode="dark"] .bc-pill--podcast { background:rgba(112,160,156,0.18); color:#70A09C; border-color:rgba(112,160,156,0.35); }
 
 /* ── Filter chips ────────────────────────────────────────── */
 .bc-filters-wrap { position:relative; flex-shrink:0; }
@@ -562,11 +567,11 @@ input, textarea { font-family: inherit; }
 .bc-type--movie.is-active   { border-color:var(--ochre); background:var(--ochre-wash); color:#7A5A26; }
 .bc-type--game.is-active    { border-color:var(--rust);  background:var(--rust-wash);  color:#72381F; }
 .bc-type--podcast.is-active { border-color:var(--teal);  background:var(--teal-wash);  color:#30504D; }
-[data-mode="dark"] .bc-type--book.is-active    { color:#c9d1a8; }
-[data-mode="dark"] .bc-type--show.is-active    { color:#d5b9d9; }
-[data-mode="dark"] .bc-type--movie.is-active   { color:#e6c896; }
-[data-mode="dark"] .bc-type--game.is-active    { color:#dca590; }
-[data-mode="dark"] .bc-type--podcast.is-active { color:#a9c4c1; }
+[data-mode="dark"] .bc-type--book.is-active    { color:#8FAF70; }
+[data-mode="dark"] .bc-type--show.is-active    { color:#A87AB0; }
+[data-mode="dark"] .bc-type--movie.is-active   { color:#D4A840; }
+[data-mode="dark"] .bc-type--game.is-active    { color:#C8784A; }
+[data-mode="dark"] .bc-type--podcast.is-active { color:#70A09C; }
 
 /* ── Status chips ────────────────────────────────────────── */
 .bc-status { display:flex; gap:6px; flex-wrap:wrap; }
@@ -824,21 +829,21 @@ input, textarea { font-family: inherit; }
 .bc-heat__cell--podcast[data-level="1"] { background:var(--teal-wash); }
 .bc-heat__cell--podcast[data-level="2"] { background:var(--teal-soft); }
 .bc-heat__cell--podcast[data-level="3"] { background:var(--teal); }
-[data-mode="dark"] .bc-heat__cell--book[data-level="1"]    { background:rgba(189,197,162,0.2); }
-[data-mode="dark"] .bc-heat__cell--book[data-level="2"]    { background:rgba(189,197,162,0.55); }
-[data-mode="dark"] .bc-heat__cell--book[data-level="3"]    { background:#BDC5A2; }
-[data-mode="dark"] .bc-heat__cell--show[data-level="1"]    { background:rgba(200,179,203,0.18); }
-[data-mode="dark"] .bc-heat__cell--show[data-level="2"]    { background:rgba(200,179,203,0.5); }
-[data-mode="dark"] .bc-heat__cell--show[data-level="3"]    { background:#C8B3CB; }
-[data-mode="dark"] .bc-heat__cell--movie[data-level="1"]   { background:rgba(224,200,150,0.18); }
-[data-mode="dark"] .bc-heat__cell--movie[data-level="2"]   { background:rgba(224,200,150,0.5); }
-[data-mode="dark"] .bc-heat__cell--movie[data-level="3"]   { background:#E0C896; }
-[data-mode="dark"] .bc-heat__cell--game[data-level="1"]    { background:rgba(217,178,158,0.18); }
-[data-mode="dark"] .bc-heat__cell--game[data-level="2"]    { background:rgba(217,178,158,0.5); }
-[data-mode="dark"] .bc-heat__cell--game[data-level="3"]    { background:#D9B29E; }
-[data-mode="dark"] .bc-heat__cell--podcast[data-level="1"] { background:rgba(173,191,189,0.18); }
-[data-mode="dark"] .bc-heat__cell--podcast[data-level="2"] { background:rgba(173,191,189,0.5); }
-[data-mode="dark"] .bc-heat__cell--podcast[data-level="3"] { background:#ADBFBD; }
+[data-mode="dark"] .bc-heat__cell--book[data-level="1"]    { background:rgba(143,175,112,0.22); }
+[data-mode="dark"] .bc-heat__cell--book[data-level="2"]    { background:rgba(143,175,112,0.58); }
+[data-mode="dark"] .bc-heat__cell--book[data-level="3"]    { background:#8FAF70; }
+[data-mode="dark"] .bc-heat__cell--show[data-level="1"]    { background:rgba(168,122,176,0.22); }
+[data-mode="dark"] .bc-heat__cell--show[data-level="2"]    { background:rgba(168,122,176,0.58); }
+[data-mode="dark"] .bc-heat__cell--show[data-level="3"]    { background:#A87AB0; }
+[data-mode="dark"] .bc-heat__cell--movie[data-level="1"]   { background:rgba(212,168,64,0.22); }
+[data-mode="dark"] .bc-heat__cell--movie[data-level="2"]   { background:rgba(212,168,64,0.58); }
+[data-mode="dark"] .bc-heat__cell--movie[data-level="3"]   { background:#D4A840; }
+[data-mode="dark"] .bc-heat__cell--game[data-level="1"]    { background:rgba(200,120,74,0.22); }
+[data-mode="dark"] .bc-heat__cell--game[data-level="2"]    { background:rgba(200,120,74,0.58); }
+[data-mode="dark"] .bc-heat__cell--game[data-level="3"]    { background:#C8784A; }
+[data-mode="dark"] .bc-heat__cell--podcast[data-level="1"] { background:rgba(112,160,156,0.22); }
+[data-mode="dark"] .bc-heat__cell--podcast[data-level="2"] { background:rgba(112,160,156,0.58); }
+[data-mode="dark"] .bc-heat__cell--podcast[data-level="3"] { background:#70A09C; }
 .bc-heat__legend {
   display:flex; justify-content:space-between; margin-top:10px;
   font-family:var(--sans-ui); font-size:10px; color:var(--fg-4);
@@ -1171,6 +1176,200 @@ input, textarea { font-family: inherit; }
   font-family:var(--sans-ui); font-size:10px; font-weight:600;
   letter-spacing:0.1em; text-transform:uppercase; color:var(--fg-4);
 }
+
+/* ── Detail panel ───────────────────────────────────────────── */
+.bc-detail-panel {
+  position: fixed; inset: 0; z-index: 60;
+  background: var(--bg);
+  display: flex; flex-direction: column;
+  transform: translateX(100%);
+  transition: transform 320ms cubic-bezier(0.25,0.1,0.25,1);
+  overflow: hidden;
+  pointer-events: none;
+}
+.bc-detail-panel.is-open { transform: translateX(0); pointer-events: auto; }
+
+.bc-detail__header {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: calc(12px + env(safe-area-inset-top,0px)) 10px 12px;
+  border-bottom: 1px solid var(--border);
+  background: color-mix(in srgb, var(--parchment) 88%, transparent);
+  backdrop-filter: blur(12px);
+  flex-shrink: 0; z-index: 2;
+}
+.bc-detail__header-title {
+  font-family: var(--serif-display); font-style: italic;
+  font-size: 18px; color: var(--fg); flex: 1; text-align: center;
+}
+.bc-detail__scroll { flex: 1; overflow-y: auto; -webkit-overflow-scrolling: touch; padding-bottom: 40px; }
+
+.bc-detail__hero {
+  min-height: 180px; position: relative; flex-shrink: 0;
+  background-size: cover; background-position: center;
+}
+.bc-detail__hero-scrim {
+  position: absolute; inset: 0;
+  background: linear-gradient(to bottom, rgba(0,0,0,0.15) 0%, rgba(0,0,0,0.65) 100%);
+}
+.bc-detail__hero-body {
+  position: relative; z-index: 1;
+  padding: 20px 20px 22px; display: flex; flex-direction: column; gap: 6px;
+  min-height: 180px; justify-content: flex-end;
+}
+.bc-detail__title {
+  font-family: var(--serif-display); font-style: italic; font-weight: 600;
+  font-size: 26px; color: #fff; line-height: 1.15; margin: 0;
+}
+.bc-detail__sub { font-size: 14px; color: rgba(255,255,255,0.75); margin: 0; font-style: italic; }
+.bc-detail__stamp {
+  display: inline-block; font-family: var(--sans-ui); font-size: 10px; font-weight: 700;
+  letter-spacing: 0.12em; text-transform: uppercase;
+  background: rgba(255,255,255,0.2); color: #fff;
+  padding: 3px 8px; border-radius: var(--r-pill); align-self: flex-start;
+}
+
+.bc-detail__body { display: flex; flex-direction: column; gap: 12px; padding: 14px 16px; }
+.bc-detail__card {
+  background: var(--bg-raised); border: 1px solid var(--border);
+  border-radius: var(--r-md); padding: 16px 18px;
+}
+.bc-detail__card-head {
+  font-family: var(--sans-ui); font-size: 10px; font-weight: 600;
+  letter-spacing: 0.14em; text-transform: uppercase; color: var(--fg-4);
+  margin-bottom: 12px; display: flex; align-items: center; justify-content: space-between;
+}
+.bc-detail__count {
+  font-family: var(--mono); font-size: 11px; color: var(--fg-4);
+  font-weight: 400; letter-spacing: 0; text-transform: none;
+}
+.bc-detail__prog-lbl {
+  font-family: var(--serif-display); font-style: italic; font-weight: 600;
+  font-size: 28px; color: var(--accent); line-height: 1; margin-bottom: 12px;
+}
+.bc-detail__track {
+  height: 8px; background: var(--bg-inset); border-radius: var(--r-pill);
+  overflow: hidden; margin-bottom: 6px;
+}
+.bc-detail__fill { height: 100%; border-radius: var(--r-pill); transition: width 600ms var(--ease-calm); }
+.bc-detail__track-row {
+  display: flex; justify-content: space-between;
+  font-family: var(--sans-ui); font-size: 10px; color: var(--fg-4);
+  margin-bottom: 14px;
+}
+.bc-detail__btns { display: flex; gap: 10px; }
+.bc-detail__log-btn { flex: 1; display: flex; align-items: center; justify-content: center; gap: 6px; }
+.bc-detail__fin-btn { flex: 1; }
+.bc-detail__no-prog { font-size: 13px; color: var(--fg-4); font-style: italic; margin: 0 0 12px; }
+
+.bc-margin-note {
+  background: var(--bg-inset); border-left: 3px solid var(--accent-soft);
+  border-radius: 0 var(--r-sm) var(--r-sm) 0;
+  padding: 14px 16px; margin: 0; position: relative;
+}
+.bc-margin-note__mark {
+  font-family: var(--serif-display); font-size: 32px; line-height: 0.5;
+  color: var(--accent-soft); position: absolute; top: 18px; left: 12px;
+}
+.bc-margin-note__text {
+  font-family: var(--serif-body); font-style: italic; font-size: 14px;
+  color: var(--fg-2); line-height: 1.55; padding-left: 18px;
+}
+
+.bc-history { display: flex; flex-direction: column; gap: 0; }
+.bc-history__item {
+  display: flex; gap: 12px; padding: 10px 0;
+  border-bottom: 1px solid var(--rule);
+}
+.bc-history__item:last-child { border-bottom: none; }
+.bc-history__dot {
+  width: 8px; height: 8px; border-radius: 50%; flex-shrink: 0; margin-top: 5px;
+}
+.bc-history__body { flex: 1; min-width: 0; }
+.bc-history__when {
+  font-family: var(--sans-ui); font-size: 10px; font-weight: 600;
+  letter-spacing: 0.08em; text-transform: uppercase; color: var(--fg-4);
+  margin-bottom: 2px;
+}
+.bc-history__what { font-family: var(--serif-body); font-size: 14px; color: var(--fg); }
+.bc-history__note {
+  font-family: var(--serif-body); font-style: italic; font-size: 13px;
+  color: var(--fg-3); margin-top: 3px; padding-left: 10px;
+  border-left: 2px solid var(--ink-whisper);
+}
+
+/* ── Add panel ──────────────────────────────────────────────── */
+.bc-addpanel {
+  position: fixed; inset: 0; z-index: 60;
+  background: var(--bg);
+  display: flex; flex-direction: column;
+  transform: translateY(100%);
+  transition: transform 320ms cubic-bezier(0.25,0.1,0.25,1);
+}
+.bc-addpanel.is-open { transform: translateY(0); }
+
+.bc-addpanel__search-wrap {
+  position: relative; padding: 10px 16px; border-bottom: 1px solid var(--rule); flex-shrink: 0;
+}
+.bc-addpanel__search-input {
+  width: 100%; padding: 10px 14px 10px 38px;
+  background: var(--bg-inset); border: 1px solid var(--border-strong);
+  border-radius: var(--r-pill); font-family: var(--serif-body); font-size: 15px; color: var(--fg);
+  box-sizing: border-box;
+}
+.bc-addpanel__search-input:focus { outline: none; border-color: var(--accent); }
+.bc-addpanel__search-input::placeholder { color: var(--fg-4); font-style: italic; }
+
+.bc-addpanel__body { flex: 1; overflow-y: auto; -webkit-overflow-scrolling: touch; }
+.bc-addpanel__section {
+  font-family: var(--sans-ui); font-size: 10px; font-weight: 600;
+  letter-spacing: 0.14em; text-transform: uppercase; color: var(--fg-4);
+  padding: 14px 18px 8px;
+}
+.bc-addpanel__row {
+  display: flex; align-items: center; gap: 12px;
+  width: 100%; padding: 10px 16px; border: none;
+  border-bottom: 1px solid var(--rule);
+  background: transparent; text-align: left; cursor: pointer; color: inherit;
+  transition: background var(--dur-quick);
+}
+.bc-addpanel__row:hover { background: var(--bg-raised); }
+.bc-addpanel__cover {
+  width: 40px; height: 58px; border-radius: var(--r-sm); flex-shrink: 0;
+  background-size: cover; background-position: center; box-shadow: var(--shadow-xs);
+}
+.bc-addpanel__info { flex: 1; min-width: 0; }
+.bc-addpanel__row-title {
+  font-family: var(--serif-display); font-style: italic; font-size: 16px; color: var(--fg);
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.bc-addpanel__row-sub {
+  font-size: 12px; color: var(--fg-3); margin-top: 2px;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.bc-addpanel__row-type {
+  font-family: var(--sans-ui); font-size: 10px; font-weight: 600;
+  letter-spacing: 0.1em; text-transform: uppercase; color: var(--fg-4); margin-top: 3px;
+}
+.bc-addpanel__empty { font-size: 14px; color: var(--fg-4); font-style: italic; padding: 20px 18px; }
+.bc-addpanel__manual {
+  padding: 20px 16px calc(20px + env(safe-area-inset-bottom));
+  border-top: 1px solid var(--rule); margin-top: 8px;
+}
+.bc-addpanel__manual-label {
+  font-family: var(--sans-ui); font-size: 11px; font-weight: 600;
+  letter-spacing: 0.1em; text-transform: uppercase; color: var(--fg-4); margin-bottom: 10px;
+}
+
+/* ── Log modal entry name ───────────────────────────────────── */
+.bc-log__entry-name {
+  font-family: var(--serif-display); font-style: italic; font-weight: 600;
+  font-size: 18px; color: var(--fg); margin-bottom: 16px; line-height: 1.2;
+}
+
+/* ── Progress row (log modal) ───────────────────────────────── */
+.bc-progrow { display: flex; align-items: center; gap: 8px; }
+.bc-progrow .bc-input { flex: 1; }
+.bc-progrow__of { font-family: var(--sans-ui); font-size: 12px; color: var(--fg-4); flex-shrink: 0; }
 
 /* ── Reduced motion ──────────────────────────────────────── */
 @media (prefers-reduced-motion: reduce) {

--- a/public/index.html
+++ b/public/index.html
@@ -467,6 +467,46 @@
 
 
 
+  <!-- ═══ DETAIL PANEL ════════════════════════════════════════ -->
+  <div class="bc-detail-panel" id="detail-panel" role="dialog" aria-modal="true" aria-label="Entry detail">
+    <div class="bc-detail__header">
+      <button class="bc-icon-btn" id="detail-back" aria-label="Back">
+        <svg width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden="true">
+          <polyline points="12,4 6,10 12,16" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" fill="none"/>
+        </svg>
+      </button>
+      <span class="bc-detail__header-title">Entry</span>
+      <button class="bc-icon-btn" id="detail-edit" aria-label="Edit entry">
+        <svg width="18" height="18" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+          <path d="M11 2l3 3-8 8H3v-3l8-8z" stroke="currentColor" stroke-width="1.3" stroke-linejoin="round" fill="none"/>
+        </svg>
+      </button>
+    </div>
+    <div class="bc-detail__scroll" id="detail-scroll">
+      <!-- populated by renderDetail() -->
+    </div>
+  </div><!-- /detail-panel -->
+
+
+  <!-- ═══ LOG MODAL ════════════════════════════════════════════ -->
+  <div class="bc-modal-bg" id="log-modal" style="display:none" role="dialog" aria-modal="true" aria-labelledby="log-modal-title">
+    <div class="bc-modal">
+      <div class="bc-modal__grip" aria-hidden="true"></div>
+      <div class="bc-modal__head">
+        <span class="bc-modal__title" id="log-modal-title">Log progress</span>
+        <button class="bc-modal__close" id="log-modal-close" aria-label="Close">✕</button>
+      </div>
+      <div class="bc-modal__body" id="log-modal-body">
+        <!-- populated by openLogModal() -->
+      </div>
+      <div class="bc-modal__actions">
+        <button class="bc-btn bc-btn--secondary" id="log-modal-cancel">Cancel</button>
+        <button class="bc-btn bc-btn--primary"   id="log-modal-save">Save</button>
+      </div>
+    </div>
+  </div><!-- /log-modal -->
+
+
   <!-- ═══ UTILITY ══════════════════════════════════════════════ -->
   <div id="toasts"
     style="position:fixed;bottom:96px;left:50%;transform:translateX(-50%);z-index:2000;display:flex;flex-direction:column;gap:8px;align-items:center;pointer-events:none;width:max-content;max-width:calc(100vw - 40px)">


### PR DESCRIPTION
- Tap any card to open a slide-in detail panel with cover hero, progress bar, notes, rating, and history timeline
- "Log progress" modal lets users record a progress snapshot with an optional note; each save appends to the entry's history array
- "Mark complete" button updates status and records a history event
- Fix scrolling blocked by fixed detail panel (pointer-events:none on closed state)
- Fix ATP lists never loaded on page refresh (call atpGetLists in loadEntries alongside atpGetEntries)
- Fix graphic novel search: fall back to OpenLibrary when Google Books returns no results (better comics/manga coverage)
- Refresh dark-mode category colors to more vivid hues across pills, type buttons, and heat map cells