### PR TITLE
Add RAWG game description to detail view synopsis

### DIFF
--- a/functions/api/rawg-detail.js
+++ b/functions/api/rawg-detail.js
@@ -1,0 +1,53 @@
+// Cloudflare Pages Function - RAWG Game Detail Proxy
+// Returns description_raw for a single game by ID
+//
+// Route: GET /api/rawg-detail?id=<game-id>
+// Env: RAWG_API_KEY
+
+export async function onRequestGet(context) {
+  const { request, env } = context;
+
+  const corsHeaders = {
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Methods': 'GET, OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type',
+  };
+
+  if (request.method === 'OPTIONS') {
+    return new Response(null, { headers: corsHeaders });
+  }
+
+  try {
+    const url = new URL(request.url);
+    const id = url.searchParams.get('id');
+
+    if (!id || !/^\d+$/.test(id)) {
+      return new Response(
+        JSON.stringify({ error: 'Missing or invalid id parameter' }),
+        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    const rawgUrl = `https://api.rawg.io/api/games/${id}?key=${env.RAWG_API_KEY}`;
+    const response = await fetch(rawgUrl);
+
+    if (!response.ok) {
+      return new Response(
+        JSON.stringify({ error: 'RAWG API error' }),
+        { status: response.status, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    const data = await response.json();
+    return new Response(
+      JSON.stringify({ description_raw: data.description_raw || '' }),
+      { headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    );
+
+  } catch (error) {
+    return new Response(
+      JSON.stringify({ error: 'Failed to fetch game details' }),
+      { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    );
+  }
+}

--- a/public/app.js
+++ b/public/app.js
@@ -1321,6 +1321,7 @@ function renderSearchResults(items) {
       + ' data-isbn13="'    + esc(item.isbn13||'')  + '"'
       + ' data-pages="'     + esc(String(item.pages||''))     + '"'
       + ' data-developer="'   + esc(item.developer||'')   + '"'
+      + ' data-rawg-id="'     + esc(String(item.rawgId||''))  + '"'
       + ' data-description="' + esc((item.description||'').slice(0,600)) + '">'
       + '<div class="bc-search-row__cover" style="' + coverStyle + '" aria-hidden="true"></div>'
       + '<div>'
@@ -1424,9 +1425,10 @@ function searchGames(query) {
       if (!data.results?.length) { renderSearchResults([]); return; }
       renderSearchResults(data.results.slice(0,6).map(function(item) {
         return {
-          title: item.name,
-          year:  (item.released||'').slice(0,4),
-          cover: item.background_image || ''
+          title:  item.name,
+          year:   (item.released||'').slice(0,4),
+          cover:  item.background_image || '',
+          rawgId: item.id
         };
       }));
     })
@@ -1455,6 +1457,14 @@ function selectResult(el) {
   $('f-search').value = '';
   $('search-results').classList.add('hidden');
   $('search-group').classList.add('hidden');
+
+  // For games, async-fetch description from RAWG detail endpoint
+  if (d.rawgId) {
+    fetch('/api/rawg-detail?id=' + encodeURIComponent(d.rawgId))
+      .then(function(r) { return r.json(); })
+      .then(function(data) { if (selectedMedia && data.description_raw) selectedMedia.description = data.description_raw; })
+      .catch(function() {});
+  }
 
   // Auto-fill progress fields from API data
   if (selType === 'book' && d.pages) {


### PR DESCRIPTION
## Summary

- Adds `functions/api/rawg-detail.js`: a Cloudflare Pages proxy that fetches a single RAWG game by ID and returns its `description_raw`
- Threads `rawgId` through `renderSearchResults` as a `data-rawg-id` attribute so game search results carry their ID
- In `selectResult`, async-fetches the description when a game is chosen and sets `selectedMedia.description` before the user saves

**Context:** The existing detail panel shows a SYNOPSIS card from `entry.description`, but game entries had no description because the RAWG list endpoint (`/api/games?search=…`) doesn't return `description_raw`. Books and movies/TV already work via Google Books and TMDB respectively.

## Test plan

- [ ] Search for a game (e.g. "Baldur's Gate 3"), select it, save entry
- [ ] Open the entry detail view — SYNOPSIS card should show the game description
- [ ] Verify books and TV/movies still show synopsis correctly (no regression)
- [ ] Check `RAWG_API_KEY` env var is set in Cloudflare Pages dashboard for the proxy to work

🤖 Generated with [Claude Code](https://claude.com/claude-code)